### PR TITLE
Change React.SFC to React.FC

### DIFF
--- a/components/CustomDialog.tsx
+++ b/components/CustomDialog.tsx
@@ -11,7 +11,7 @@ interface ICustomDialogProps {
   open: boolean;
   handleClose: () => void;
 }
-const CustomDialog: React.SFC<ICustomDialogProps> = ({open, handleClose}) => (
+const CustomDialog: React.FC<ICustomDialogProps> = ({open, handleClose}) => (
   <Dialog open={open} onClose={handleClose}>
     <DialogTitle>It Works</DialogTitle>
     <DialogContent>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }),                          {withTheme: true});
 
-const Index: React.SFC = () => {
+const Index: React.FC = () => {
   const [open, setOpen] = React.useState(false);
 
   const handleOpenLink = (href: string) => {


### PR DESCRIPTION
React.SFC is deprecated. SFC stands for Stateless Functional Component.
Functional Component nowadays could be stateful now as Hooks released.

Details: https://twitter.com/dan_abramov/status/1057625147216220162