### PR TITLE
Fix loading favicon when loading site from non-root path

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -13,7 +13,7 @@ class MyDocument extends Document {
           {/* Use minimum-scale=1 to enable GPU rasterization */}
           <link
             rel="shortcut icon"
-            href="favicon.ico"
+            href="/favicon.ico"
             type="image/x-icon"
           ></link>
           {/* PWA primary color */}


### PR DESCRIPTION
There is a bug where if you do a first-time load on a non-root path (in my case `/users/current`) it will try to load the favicon from that path (eg. /users/favicon.ico). This is fixed by simply adding a forward slash to the start of the href.