### PR TITLE
Updated theme.ts

### DIFF
--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,10 +1,10 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { green } from '@material-ui/core/colors';
 
 // A theme with custom primary and secondary color.
 // It's optional.
 
-const theme = createMuiTheme({
+const theme = createTheme({
   drawerWidth: 240,
   palette: {
     primary: {
@@ -23,5 +23,3 @@ const theme = createMuiTheme({
 } as any);
 export type Theme = typeof theme;
 export default theme;
-
-


### PR DESCRIPTION
Change in import of @material-ui/core/styles
because `createMuiTheme` is now deprecated